### PR TITLE
fixed safari videos issue

### DIFF
--- a/src/components/VideosList.vue
+++ b/src/components/VideosList.vue
@@ -5,7 +5,7 @@
         <div v-for="video in content" :key="renderContentId(video)" class="flex flex-col rounded-lg shadow-md hover:shadow-xl overflow-hidden">
           <router-link :to="'/videos/' + renderContentId(video)">
             <div class="flex-shrink-0">
-              <div class="h-50 w-full object-cover flex justify-center">
+              <div class="w-full object-cover flex justify-center">
                 <div class="absolute h-40 flex flex-col">
                   <div class="pt-12">
                     <p class="text-sm font-medium text-near-green text-center">
@@ -17,7 +17,7 @@
                   </div>
                   <PlayIcon class="mt-5 text-white w-10 mx-auto" />
                 </div>
-                <img src="@/assets/video-thumbnail.png" alt="logo" />
+                <img src="@/assets/video-thumbnail.png" alt="logo" class="h-52" />
               </div>
             </div>
 


### PR DESCRIPTION
Safari was showing the videos like this:

<img width="1241" alt="Screen Shot 2021-07-30 at 9 29 26 PM" src="https://user-images.githubusercontent.com/58190902/127696587-628ec9f6-2ef6-4c37-965d-900dfef16fa4.png">


Now it's fixed:

![Screen Shot 2021-07-30 at 9 29 33 PM](https://user-images.githubusercontent.com/58190902/127696600-79248605-e3bb-48d2-9793-5b4af15d679b.png)
